### PR TITLE
Adjust CODE_128 to handle odd number of digits

### DIFF
--- a/src/BarcodeGenerator.php
+++ b/src/BarcodeGenerator.php
@@ -1281,12 +1281,21 @@ abstract class BarcodeGenerator
                     $end_offset = 0;
                     foreach ($numseq[1] as $val) {
                         $offset = $val[1];
+                        
+                        // numeric sequence
+						$slen = strlen($val[0]);
+						if (($slen % 2) != 0) {
+							// the length must be even
+							++$offset;
+							$val[0] = substr($val[0],1);
+						}
+                        
                         if ($offset > $end_offset) {
                             // non numeric sequence
                             $sequence = array_merge($sequence,
                                 $this->get128ABsequence(substr($code, $end_offset, ($offset - $end_offset))));
                         }
-                        // numeric sequence
+                        // numeric sequence fallback
                         $slen = strlen($val[0]);
                         if (($slen % 2) != 0) {
                             // the length must be even

--- a/src/BarcodeGenerator.php
+++ b/src/BarcodeGenerator.php
@@ -1283,12 +1283,12 @@ abstract class BarcodeGenerator
                         $offset = $val[1];
                         
                         // numeric sequence
-						$slen = strlen($val[0]);
-						if (($slen % 2) != 0) {
-							// the length must be even
-							++$offset;
-							$val[0] = substr($val[0],1);
-						}
+                        $slen = strlen($val[0]);
+                        if (($slen % 2) != 0) {
+                            // the length must be even
+                            ++$offset;
+                            $val[0] = substr($val[0],1);
+                        }
                         
                         if ($offset > $end_offset) {
                             // non numeric sequence


### PR DESCRIPTION
This is a change so that handling for CODE_128 auto takes into account an odd number of digits after an initial string. This then works for international DPD shipping integration "NOTE: If the postcode is all numeric, use subset B for the first 2 digits of the data
string, e.g. %0, followed by subset C for the rest of the barcode."

Example %008099915501071048275101276
Previously this would output
 * SUBSET B = %, length 1
 * SUBSET C = 00809991550107104827510127, length 26
 * SUBSET B = 6, length 1
Now expected outcome is
 * SUBSET B = %0, length 2
 * SUBSET C = 08099915501071048275101276, length 26