### PR TITLE
Fix failing test by throwing expected exception

### DIFF
--- a/src/BarcodeGenerator.php
+++ b/src/BarcodeGenerator.php
@@ -1502,7 +1502,11 @@ abstract class BarcodeGenerator
         }
         $sum_b = 0;
         for ($i = 0; $i < $data_len; $i += 2) {
-            $sum_b += ($code{$i});
+            try{
+                $sum_b += ($code{$i});
+            } catch(\Exception $e) {
+                throw new InvalidCharacterException();
+            }
         }
         if ($len < 13) {
             $sum_b *= 3;


### PR DESCRIPTION
Running tests threw an error:

```bash
1) BarcodeTest::ean13_generator_throws_exception_if_invalid_chars_are_used
A non-numeric value encountered

/app/src/BarcodeGenerator.php:1505
/app/src/BarcodeGenerator.php:148
/app/src/BarcodeGeneratorSVG.php:21
/app/tests/BarcodeTest.php:54
```

Wrapped BarcodeGenerator.php:1505 to throw the proper exception.