### PR TITLE
PHP 7.4

### DIFF
--- a/src/BarcodeGenerator.php
+++ b/src/BarcodeGenerator.php
@@ -290,7 +290,7 @@ abstract class BarcodeGenerator
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = $code{$i};
+            $char = $code[$i];
             if ( ! isset($chr[$char])) {
                 throw new InvalidCharacterException('Char ' . $char . ' is unsupported');
             }
@@ -300,7 +300,7 @@ abstract class BarcodeGenerator
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -456,10 +456,10 @@ abstract class BarcodeGenerator
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 throw new InvalidCharacterException('Only supports till char 127');
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
 
         return $code_ext;
@@ -522,7 +522,7 @@ abstract class BarcodeGenerator
         $sum = 0;
         $codelength = strlen($code);
         for ($i = 0; $i < $codelength; ++$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $sum += $k[0];
         }
         $j = ($sum % 43);
@@ -723,10 +723,10 @@ abstract class BarcodeGenerator
         $code_ext = '';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            if (ord($code{$i}) > 127) {
+            if (ord($code[$i]) > 127) {
                 throw new InvalidCharacterException('Only supports till char 127');
             }
-            $code_ext .= $encode[$code{$i}];
+            $code_ext .= $encode[$code[$i]];
         }
         // checksum
         $code_ext .= $this->checksum_code93($code_ext);
@@ -736,7 +736,7 @@ abstract class BarcodeGenerator
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $char = ord($code{$i});
+            $char = ord($code[$i]);
             if ( ! isset($chr[$char])) {
                 throw new InvalidCharacterException('Char ' . $char . ' is unsupported');
             }
@@ -746,7 +746,7 @@ abstract class BarcodeGenerator
                 } else {
                     $t = false; // space
                 }
-                $w = $chr[$char]{$j};
+                $w = $chr[$char][$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -823,7 +823,7 @@ abstract class BarcodeGenerator
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 20) {
@@ -837,7 +837,7 @@ abstract class BarcodeGenerator
         $p = 1;
         $check = 0;
         for ($i = $len; $i >= 0; --$i) {
-            $k = array_keys($chars, $code{$i});
+            $k = array_keys($chars, $code[$i]);
             $check += ($k[0] * $p);
             ++$p;
             if ($p > 15) {
@@ -865,11 +865,11 @@ abstract class BarcodeGenerator
         $len = strlen($code);
         $sum = 0;
         for ($i = 0; $i < $len; $i += 2) {
-            $sum += $code{$i};
+            $sum += $code[$i];
         }
         $sum *= 3;
         for ($i = 1; $i < $len; $i += 2) {
-            $sum += ($code{$i});
+            $sum += ($code[$i]);
         }
         $r = $sum % 10;
         if ($r > 0) {
@@ -913,7 +913,7 @@ abstract class BarcodeGenerator
             $p = 2;
             $check = 0;
             for ($i = ($clen - 1); $i >= 0; --$i) {
-                $check += (hexdec($code{$i}) * $p);
+                $check += (hexdec($code[$i]) * $p);
                 ++$p;
                 if ($p > 7) {
                     $p = 2;
@@ -928,7 +928,7 @@ abstract class BarcodeGenerator
         $seq = '110'; // left guard
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if ( ! isset($chr[$digit])) {
                 throw new InvalidCharacterException('Char ' . $digit . ' is unsupported');
             }
@@ -973,7 +973,7 @@ abstract class BarcodeGenerator
         $seq = '11011010';
         $clen = strlen($code);
         for ($i = 0; $i < $clen; ++$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if ( ! isset($chr[$digit])) {
                 throw new InvalidCharacterException('Char ' . $digit . ' is unsupported');
             }
@@ -1001,8 +1001,8 @@ abstract class BarcodeGenerator
         $k = 0;
         for ($i = 0; $i < $len; ++$i) {
             $w += 1;
-            if (($i == ($len - 1)) OR (($i < ($len - 1)) AND ($seq{$i} != $seq{($i + 1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($len - 1)) OR (($i < ($len - 1)) AND ($seq[$i] != $seq[($i + 1)]))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -1056,8 +1056,8 @@ abstract class BarcodeGenerator
         $k = 0;
         $clen = strlen($code);
         for ($i = 0; $i < $clen; $i = ($i + 2)) {
-            $char_bar = $code{$i};
-            $char_space = $code{$i + 1};
+            $char_bar = $code[$i];
+            $char_space = $code[$i + 1];
             if ( ! isset($chr[$char_bar]) || ! isset($chr[$char_space])) {
                 throw new InvalidCharacterException();
             }
@@ -1065,7 +1065,7 @@ abstract class BarcodeGenerator
             $seq = '';
             $chrlen = strlen($chr[$char_bar]);
             for ($s = 0; $s < $chrlen; $s++) {
-                $seq .= $chr[$char_bar]{$s} . $chr[$char_space]{$s};
+                $seq .= $chr[$char_bar][$s] . $chr[$char_space][$s];
             }
             $seqlen = strlen($seq);
             for ($j = 0; $j < $seqlen; ++$j) {
@@ -1074,7 +1074,7 @@ abstract class BarcodeGenerator
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -1224,7 +1224,7 @@ abstract class BarcodeGenerator
             case 'A': { // MODE A
                 $startid = 103;
                 for ($i = 0; $i < $len; ++$i) {
-                    $char = $code{$i};
+                    $char = $code[$i];
                     $char_id = ord($char);
                     if (($char_id >= 241) AND ($char_id <= 244)) {
                         $code_data[] = $fnc_a[$char_id];
@@ -1239,7 +1239,7 @@ abstract class BarcodeGenerator
             case 'B': { // MODE B
                 $startid = 104;
                 for ($i = 0; $i < $len; ++$i) {
-                    $char = $code{$i};
+                    $char = $code[$i];
                     $char_id = ord($char);
                     if (($char_id >= 241) AND ($char_id <= 244)) {
                         $code_data[] = $fnc_b[$char_id];
@@ -1262,7 +1262,7 @@ abstract class BarcodeGenerator
                     throw new InvalidLengthException('Length must be even');
                 }
                 for ($i = 0; $i < $len; $i += 2) {
-                    $chrnum = $code{$i} . $code{$i + 1};
+                    $chrnum = $code[$i] . $code[$i + 1];
                     if (preg_match('/([0-9]{2})/', $chrnum) > 0) {
                         $code_data[] = intval($chrnum);
                     } else {
@@ -1328,7 +1328,7 @@ abstract class BarcodeGenerator
                                 }
                             }
                             for ($i = 0; $i < $seq[2]; ++$i) {
-                                $char = $seq[1]{$i};
+                                $char = $seq[1][$i];
                                 $char_id = ord($char);
                                 if (($char_id >= 241) AND ($char_id <= 244)) {
                                     $code_data[] = $fnc_a[$char_id];
@@ -1371,7 +1371,7 @@ abstract class BarcodeGenerator
                                 }
                             }
                             for ($i = 0; $i < $seq[2]; ++$i) {
-                                $char = $seq[1]{$i};
+                                $char = $seq[1][$i];
                                 $char_id = ord($char);
                                 if (($char_id >= 241) AND ($char_id <= 244)) {
                                     $code_data[] = $fnc_b[$char_id];
@@ -1388,7 +1388,7 @@ abstract class BarcodeGenerator
                                 $code_data[] = 99;
                             }
                             for ($i = 0; $i < $seq[2]; $i += 2) {
-                                $chrnum = $seq[1]{$i} . $seq[1]{$i + 1};
+                                $chrnum = $seq[1][$i] . $seq[1][$i + 1];
                                 $code_data[] = intval($chrnum);
                             }
                             break;
@@ -1419,7 +1419,7 @@ abstract class BarcodeGenerator
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
             }
@@ -1495,14 +1495,14 @@ abstract class BarcodeGenerator
         // calculate check digit
         $sum_a = 0;
         for ($i = 1; $i < $data_len; $i += 2) {
-            $sum_a += $code{$i};
+            $sum_a += $code[$i];
         }
         if ($len > 12) {
             $sum_a *= 3;
         }
         $sum_b = 0;
         for ($i = 0; $i < $data_len; $i += 2) {
-            $sum_b += ($code{$i});
+            $sum_b += ($code[$i]);
         }
         if ($len < 13) {
             $sum_b *= 3;
@@ -1514,7 +1514,7 @@ abstract class BarcodeGenerator
         if ($code_len == $data_len) {
             // add check digit
             $code .= $r;
-        } elseif ($r !== intval($code{$data_len})) {
+        } elseif ($r !== intval($code[$data_len])) {
             throw new InvalidCheckDigitException();
         }
         if ($len == 12) {
@@ -1627,7 +1627,7 @@ abstract class BarcodeGenerator
             $bararray = array('code' => $upce_code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
             $p = $upce_parities[$code[1]][$r];
             for ($i = 0; $i < 6; ++$i) {
-                $seq .= $codes[$p[$i]][$upce_code{$i}];
+                $seq .= $codes[$p[$i]][$upce_code[$i]];
             }
             $seq .= '010101'; // right guard bar
         } else {
@@ -1635,20 +1635,20 @@ abstract class BarcodeGenerator
             $half_len = intval(ceil($len / 2));
             if ($len == 8) {
                 for ($i = 0; $i < $half_len; ++$i) {
-                    $seq .= $codes['A'][$code{$i}];
+                    $seq .= $codes['A'][$code[$i]];
                 }
             } else {
                 $p = $parities[$code[0]];
                 for ($i = 1; $i < $half_len; ++$i) {
-                    $seq .= $codes[$p[$i - 1]][$code{$i}];
+                    $seq .= $codes[$p[$i - 1]][$code[$i]];
                 }
             }
             $seq .= '01010'; // center guard bar
             for ($i = $half_len; $i < $len; ++$i) {
-                if ( ! isset($codes['C'][$code{$i}])) {
-                    throw new InvalidCharacterException('Char ' . $code{$i} . ' not allowed');
+                if ( ! isset($codes['C'][$code[$i]])) {
+                    throw new InvalidCharacterException('Char ' . $code[$i] . ' not allowed');
                 }
-                $seq .= $codes['C'][$code{$i}];
+                $seq .= $codes['C'][$code[$i]];
             }
             $seq .= '101'; // right guard bar
         }
@@ -1656,8 +1656,8 @@ abstract class BarcodeGenerator
         $w = 0;
         for ($i = 0; $i < $clen; ++$i) {
             $w += 1;
-            if (($i == ($clen - 1)) OR (($i < ($clen - 1)) AND ($seq{$i} != $seq{($i + 1)}))) {
-                if ($seq{$i} == '1') {
+            if (($i == ($clen - 1)) OR (($i < ($clen - 1)) AND ($seq[$i] != $seq[($i + 1)]))) {
+                if ($seq[$i] == '1') {
                     $t = true; // bar
                 } else {
                     $t = false; // space
@@ -1746,7 +1746,7 @@ abstract class BarcodeGenerator
         $seq .= $codes[$p[0]][$code[0]];
         for ($i = 1; $i < $len; ++$i) {
             $seq .= '01'; // separator
-            $seq .= $codes[$p[$i]][$code{$i}];
+            $seq .= $codes[$p[$i]][$code[$i]];
         }
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 1, 'bcode' => array());
 
@@ -1801,7 +1801,7 @@ abstract class BarcodeGenerator
         // calculate checksum
         $sum = 0;
         for ($i = 0; $i < $len; ++$i) {
-            $sum += intval($code{$i});
+            $sum += intval($code[$i]);
         }
         $chkd = ($sum % 10);
         if ($chkd > 0) {
@@ -1815,7 +1815,7 @@ abstract class BarcodeGenerator
         $bararray['maxw'] += 2;
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 5; ++$j) {
-                $h = $barlen[$code{$i}][$j];
+                $h = $barlen[$code[$i]][$j];
                 $p = floor(1 / $h);
                 $bararray['bcode'][$k++] = array('t' => 1, 'w' => 1, 'h' => $h, 'p' => $p);
                 $bararray['bcode'][$k++] = array('t' => 0, 'w' => 1, 'h' => 2, 'p' => 0);
@@ -1932,8 +1932,8 @@ abstract class BarcodeGenerator
             $row = 0;
             $col = 0;
             for ($i = 0; $i < $len; ++$i) {
-                $row += $checktable[$code{$i}][0];
-                $col += $checktable[$code{$i}][1];
+                $row += $checktable[$code[$i]][0];
+                $col += $checktable[$code[$i]][1];
             }
             $row %= 6;
             $col %= 6;
@@ -1950,7 +1950,7 @@ abstract class BarcodeGenerator
         }
         for ($i = 0; $i < $len; ++$i) {
             for ($j = 0; $j < 4; ++$j) {
-                switch ($barmode[$code{$i}][$j]) {
+                switch ($barmode[$code[$i]][$j]) {
                     case 1: {
                         $p = 0;
                         $h = 2;
@@ -2025,17 +2025,17 @@ abstract class BarcodeGenerator
         $code = 'A' . strtoupper($code) . 'A';
         $len = strlen($code);
         for ($i = 0; $i < $len; ++$i) {
-            if ( ! isset($chr[$code{$i}])) {
-                throw new InvalidCharacterException('Char ' . $code{$i} . ' is unsupported');
+            if ( ! isset($chr[$code[$i]])) {
+                throw new InvalidCharacterException('Char ' . $code[$i] . ' is unsupported');
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 8; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$i];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -2078,7 +2078,7 @@ abstract class BarcodeGenerator
         $p = 1;
         $check = 0;
         for ($i = ($len - 1); $i >= 0; --$i) {
-            $digit = $code{$i};
+            $digit = $code[$i];
             if ($digit == '-') {
                 $dval = 10;
             } else {
@@ -2100,7 +2100,7 @@ abstract class BarcodeGenerator
             $p = 1;
             $check = 0;
             for ($i = $len; $i >= 0; --$i) {
-                $digit = $code{$i};
+                $digit = $code[$i];
                 if ($digit == '-') {
                     $dval = 10;
                 } else {
@@ -2119,17 +2119,17 @@ abstract class BarcodeGenerator
         $code = 'S' . $code . 'S';
         $len += 3;
         for ($i = 0; $i < $len; ++$i) {
-            if ( ! isset($chr[$code{$i}])) {
-                throw new InvalidCharacterException('Char ' . $code{$i} . ' is unsupported');
+            if ( ! isset($chr[$code[$i]])) {
+                throw new InvalidCharacterException('Char ' . $code[$i] . ' is unsupported');
             }
-            $seq = $chr[$code{$i}];
+            $seq = $chr[$code[$i]];
             for ($j = 0; $j < 6; ++$j) {
                 if (($j % 2) == 0) {
                     $t = true; // bar
                 } else {
                     $t = false; // space
                 }
-                $w = $seq{$j};
+                $w = $seq[$j];
                 $bararray['bcode'][$k] = array('t' => $t, 'w' => $w, 'h' => 1, 'p' => 0);
                 $bararray['maxw'] += $w;
                 ++$k;
@@ -2204,7 +2204,7 @@ abstract class BarcodeGenerator
         $bararray = array('code' => $code, 'maxw' => 0, 'maxh' => 2, 'bcode' => array());
         $len = strlen($seq);
         for ($i = 0; $i < $len; ++$i) {
-            switch ($seq{$i}) {
+            switch ($seq[$i]) {
                 case '1': {
                     $p = 1;
                     $h = 1;
@@ -2732,7 +2732,7 @@ abstract class BarcodeGenerator
         $bitval = 1;
         $len = strlen($hex);
         for ($pos = ($len - 1); $pos >= 0; --$pos) {
-            $dec = bcadd($dec, bcmul(hexdec($hex{$pos}), $bitval));
+            $dec = bcadd($dec, bcmul(hexdec($hex[$pos]), $bitval));
             $bitval = bcmul($bitval, 16);
         }
 

--- a/src/BarcodeGenerator.php
+++ b/src/BarcodeGenerator.php
@@ -1502,7 +1502,7 @@ abstract class BarcodeGenerator
         }
         $sum_b = 0;
         for ($i = 0; $i < $data_len; $i += 2) {
-            $sum_b += ($code[$i]);
+            $sum_b += intval(($code[$i]));
         }
         if ($len < 13) {
             $sum_b *= 3;


### PR DESCRIPTION
This PR contains two commits related to supporting later versions of PHP.

The main bulk is  feae1e0 which fixes all string and array index access using {} which was deprecated in PHP 7.4.

The second commit fixes a failing test in PHP 7.1 and onward.