### PR TITLE
Fixing a bug in Code 39 Extended (with or without checksum)

### DIFF
--- a/src/Types/TypeCode39.php
+++ b/src/Types/TypeCode39.php
@@ -70,8 +70,6 @@ class TypeCode39 implements TypeInterface
             throw new InvalidLengthException('You should provide a barcode string.');
         }
 
-        $code = strtoupper($code);
-
         if ($this->extended) {
             // extended mode
             $code = $this->encode_code39_ext($code);

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -7,17 +7,25 @@ class TypesTest extends TestCase
     public function test_generator_can_generate_code_39_barcode()
     {
         $generator = new Picqer\Barcode\BarcodeGeneratorSVG();
-        $result = $generator->getBarcode('1234567890abcABC', $generator::TYPE_CODE_39);
+        $result = $generator->getBarcode('1234567890ABC', $generator::TYPE_CODE_39);
 
-        $this->assertStringEqualsFile('tests/verified-files/C39-1234567890abcABC.svg', $result);
+        $this->assertStringEqualsFile('tests/verified-files/C39-1234567890ABC.svg', $result);
     }
 
     public function test_generator_can_generate_code_39_checksum_barcode()
     {
         $generator = new Picqer\Barcode\BarcodeGeneratorSVG();
-        $result = $generator->getBarcode('1234567890abcABC', $generator::TYPE_CODE_39_CHECKSUM);
+        $result = $generator->getBarcode('1234567890ABC', $generator::TYPE_CODE_39_CHECKSUM);
 
         $this->assertGreaterThan(100, strlen($result));
+    }
+
+    public function test_generator_can_generate_code_39_extended_barcode()
+    {
+        $generator = new Picqer\Barcode\BarcodeGeneratorSVG();
+        $result = $generator->getBarcode('1234567890abcABC', $generator::TYPE_CODE_39E);
+
+        $this->assertStringEqualsFile('tests/verified-files/C39E-1234567890abcABC.svg', $result);
     }
 
     public function test_generator_can_generate_code_39_extended_checksum_barcode()

--- a/tests/VerifiedBarcodeTest.php
+++ b/tests/VerifiedBarcodeTest.php
@@ -14,8 +14,9 @@ use Picqer\Barcode\BarcodeGenerator;
 class VerifiedBarcodeTest extends TestCase
 {
     public static $supportedBarcodes = [
-        ['type' => BarcodeGenerator::TYPE_CODE_39, 'barcodes' => ['1234567890abcABC']],
-        ['type' => BarcodeGenerator::TYPE_CODE_39_CHECKSUM, 'barcodes' => ['1234567890abcABC']],
+        ['type' => BarcodeGenerator::TYPE_CODE_39, 'barcodes' => ['1234567890ABC']],
+        ['type' => BarcodeGenerator::TYPE_CODE_39_CHECKSUM, 'barcodes' => ['1234567890ABC']],
+        ['type' => BarcodeGenerator::TYPE_CODE_39E, 'barcodes' => ['1234567890abcABC']],
         ['type' => BarcodeGenerator::TYPE_CODE_39E_CHECKSUM, 'barcodes' => ['1234567890abcABC']],
         ['type' => BarcodeGenerator::TYPE_CODE_93, 'barcodes' => ['1234567890abcABC']],
         ['type' => BarcodeGenerator::TYPE_STANDARD_2_5, 'barcodes' => ['1234567890']],

--- a/tests/verified-files/C39+-1234567890ABC.svg
+++ b/tests/verified-files/C39+-1234567890ABC.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no" ?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="576" height="30" viewBox="0 0 576 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
-	<desc>*1234567890ABCABC*</desc>
+<svg width="512" height="30" viewBox="0 0 512 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
+	<desc>*1234567890ABCZ*</desc>
 	<g id="bars" fill="black" stroke="none">
 		<rect x="0" y="0" width="2" height="30" />
 		<rect x="8" y="0" width="2" height="30" />
@@ -73,25 +73,15 @@
 		<rect x="432" y="0" width="2" height="30" />
 		<rect x="440" y="0" width="2" height="30" />
 		<rect x="444" y="0" width="2" height="30" />
-		<rect x="448" y="0" width="6" height="30" />
-		<rect x="456" y="0" width="2" height="30" />
-		<rect x="460" y="0" width="2" height="30" />
-		<rect x="468" y="0" width="2" height="30" />
-		<rect x="472" y="0" width="6" height="30" />
+		<rect x="448" y="0" width="2" height="30" />
+		<rect x="456" y="0" width="6" height="30" />
+		<rect x="464" y="0" width="6" height="30" />
+		<rect x="472" y="0" width="2" height="30" />
+		<rect x="476" y="0" width="2" height="30" />
 		<rect x="480" y="0" width="2" height="30" />
-		<rect x="484" y="0" width="6" height="30" />
-		<rect x="492" y="0" width="2" height="30" />
-		<rect x="500" y="0" width="2" height="30" />
-		<rect x="504" y="0" width="6" height="30" />
-		<rect x="512" y="0" width="6" height="30" />
-		<rect x="520" y="0" width="6" height="30" />
-		<rect x="528" y="0" width="2" height="30" />
-		<rect x="536" y="0" width="2" height="30" />
-		<rect x="540" y="0" width="2" height="30" />
-		<rect x="544" y="0" width="2" height="30" />
-		<rect x="552" y="0" width="2" height="30" />
-		<rect x="556" y="0" width="6" height="30" />
-		<rect x="564" y="0" width="6" height="30" />
-		<rect x="572" y="0" width="2" height="30" />
+		<rect x="488" y="0" width="2" height="30" />
+		<rect x="492" y="0" width="6" height="30" />
+		<rect x="500" y="0" width="6" height="30" />
+		<rect x="508" y="0" width="2" height="30" />
 	</g>
 </svg>

--- a/tests/verified-files/C39-1234567890ABC.svg
+++ b/tests/verified-files/C39-1234567890ABC.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no" ?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="608" height="30" viewBox="0 0 608 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
-	<desc>*1234567890ABCABCP*</desc>
+<svg width="480" height="30" viewBox="0 0 480 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
+	<desc>*1234567890ABC*</desc>
 	<g id="bars" fill="black" stroke="none">
 		<rect x="0" y="0" width="2" height="30" />
 		<rect x="8" y="0" width="2" height="30" />
@@ -73,30 +73,10 @@
 		<rect x="432" y="0" width="2" height="30" />
 		<rect x="440" y="0" width="2" height="30" />
 		<rect x="444" y="0" width="2" height="30" />
-		<rect x="448" y="0" width="6" height="30" />
+		<rect x="448" y="0" width="2" height="30" />
 		<rect x="456" y="0" width="2" height="30" />
-		<rect x="460" y="0" width="2" height="30" />
-		<rect x="468" y="0" width="2" height="30" />
-		<rect x="472" y="0" width="6" height="30" />
-		<rect x="480" y="0" width="2" height="30" />
-		<rect x="484" y="0" width="6" height="30" />
-		<rect x="492" y="0" width="2" height="30" />
-		<rect x="500" y="0" width="2" height="30" />
-		<rect x="504" y="0" width="6" height="30" />
-		<rect x="512" y="0" width="6" height="30" />
-		<rect x="520" y="0" width="6" height="30" />
-		<rect x="528" y="0" width="2" height="30" />
-		<rect x="536" y="0" width="2" height="30" />
-		<rect x="540" y="0" width="2" height="30" />
-		<rect x="544" y="0" width="2" height="30" />
-		<rect x="548" y="0" width="6" height="30" />
-		<rect x="556" y="0" width="6" height="30" />
-		<rect x="564" y="0" width="2" height="30" />
-		<rect x="572" y="0" width="2" height="30" />
-		<rect x="576" y="0" width="2" height="30" />
-		<rect x="584" y="0" width="2" height="30" />
-		<rect x="588" y="0" width="6" height="30" />
-		<rect x="596" y="0" width="6" height="30" />
-		<rect x="604" y="0" width="2" height="30" />
+		<rect x="460" y="0" width="6" height="30" />
+		<rect x="468" y="0" width="6" height="30" />
+		<rect x="476" y="0" width="2" height="30" />
 	</g>
 </svg>

--- a/tests/verified-files/C39E-1234567890abcABC.svg
+++ b/tests/verified-files/C39E-1234567890abcABC.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no" ?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="704" height="30" viewBox="0 0 704 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
-	<desc>*1234567890+A+B+CABCJ*</desc>
+<svg width="672" height="30" viewBox="0 0 672 30" version="1.1" xmlns="http://www.w3.org/2000/svg">
+	<desc>*1234567890+A+B+CABC*</desc>
 	<g id="bars" fill="black" stroke="none">
 		<rect x="0" y="0" width="2" height="30" />
 		<rect x="8" y="0" width="2" height="30" />
@@ -104,14 +104,9 @@
 		<rect x="632" y="0" width="2" height="30" />
 		<rect x="636" y="0" width="2" height="30" />
 		<rect x="640" y="0" width="2" height="30" />
-		<rect x="644" y="0" width="2" height="30" />
-		<rect x="648" y="0" width="6" height="30" />
+		<rect x="648" y="0" width="2" height="30" />
+		<rect x="652" y="0" width="6" height="30" />
 		<rect x="660" y="0" width="6" height="30" />
 		<rect x="668" y="0" width="2" height="30" />
-		<rect x="672" y="0" width="2" height="30" />
-		<rect x="680" y="0" width="2" height="30" />
-		<rect x="684" y="0" width="6" height="30" />
-		<rect x="692" y="0" width="6" height="30" />
-		<rect x="700" y="0" width="2" height="30" />
 	</g>
 </svg>


### PR DESCRIPTION
While testing Code 39 Extended (after the issue "[Error with checksum of Code 39E](https://github.com/picqer/php-barcode-generator/issues/140)" has been fixed), I found another bug: Lower case letters (which are supported in extended mode) were always printed as upper case letters. This pull request fixes the bug.