### PR TITLE
Added consistency on PNG/JPG classes and tests

### DIFF
--- a/src/BarcodeGeneratorImage.php
+++ b/src/BarcodeGeneratorImage.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Picqer\Barcode;
+
+use Imagick;
+use imagickdraw;
+use imagickpixel;
+use Picqer\Barcode\Exceptions\BarcodeException;
+
+abstract class BarcodeGeneratorImage extends BarcodeGenerator
+{
+	protected $useImagick = true;
+
+	public function __construct()
+	{
+		// Auto switch between GD and Imagick based on what is installed
+		if (extension_loaded('imagick')) {
+			$this->useImagick = true;
+		} elseif (function_exists('imagecreate')) {
+			$this->useImagick = false;
+		} else {
+			throw new BarcodeException('Neither gd-lib or imagick are installed!');
+		}
+	}
+
+	/**
+	 * Force the use of Imagick image extension
+	 */
+	public function useImagick()
+	{
+		$this->useImagick = true;
+	}
+
+	/**
+	 * Force the use of the GD image library
+	 */
+	public function useGd()
+	{
+		$this->useImagick = false;
+	}
+
+	/**
+	 * Return a PNG image representation of barcode (requires GD or Imagick library).
+	 *
+	 * @param string $barcode code to print
+	 * @param string $type type of barcode:
+	 * @param int $widthFactor Width of a single bar element in pixels.
+	 * @param int $height Height of a single bar element in pixels.
+	 * @param array $foregroundColor RGB (0-255) foreground color for bar elements (background is transparent).
+	 * @return string image data or false in case of error.
+	 */
+	public function getBarcode($barcode, $type, int $widthFactor = 2, int $height = 30, array $foregroundColor = [0, 0, 0])
+	{
+		$barcodeData = $this->getBarcodeData($barcode, $type);
+		$width = round($barcodeData->getWidth() * $widthFactor);
+
+		if ($this->useImagick) {
+			$imagickBarsShape = new imagickdraw();
+			$imagickBarsShape->setFillColor(new imagickpixel('rgb(' . implode(',', $foregroundColor) .')'));
+		} else {
+			$image = $this->createGdImageObject($width, $height);
+			$gdForegroundColor = imagecolorallocate($image, $foregroundColor[0], $foregroundColor[1], $foregroundColor[2]);
+		}
+
+		// print bars
+		$positionHorizontal = 0;
+		/** @var BarcodeBar $bar */
+		foreach ($barcodeData->getBars() as $bar) {
+			$barWidth = round(($bar->getWidth() * $widthFactor), 3);
+
+			if ($bar->isBar() && $barWidth > 0) {
+				$y = round(($bar->getPositionVertical() * $height / $barcodeData->getHeight()), 3);
+				$barHeight = round(($bar->getHeight() * $height / $barcodeData->getHeight()), 3);
+
+				// draw a vertical bar
+				if ($this->useImagick && isset($imagickBarsShape)) {
+					$imagickBarsShape->rectangle($positionHorizontal, $y, ($positionHorizontal + $barWidth - 1), ($y + $barHeight));
+				} else {
+					imagefilledrectangle($image, $positionHorizontal, $y, ($positionHorizontal + $barWidth - 1), ($y + $barHeight), $gdForegroundColor);
+				}
+			}
+			$positionHorizontal += $barWidth;
+		}
+
+		if ($this->useImagick && isset($imagickBarsShape)) {
+			$image = $this->createImagickImageObject($width, $height);
+			$image->drawImage($imagickBarsShape);
+			return $image->getImageBlob();
+		}
+
+		ob_start();
+		$this->generateGdImage($image);
+		return ob_get_clean();
+	}
+
+	protected function createGdImageObject(int $width, int $height)
+	{
+		$image = imagecreate($width, $height);
+		$colorBackground = imagecolorallocate($image, 255, 255, 255);
+		imagecolortransparent($image, $colorBackground);
+
+		return $image;
+	}
+
+	protected function createImagickImageObject(int $width, int $height): Imagick
+	{
+		$image = new Imagick();
+		$image->newImage($width, $height, static::DEFAULT_BACKGROUND_COLOR, static::EXTENSION);
+
+		return $image;
+	}
+
+	protected function generateGdImage($image)
+	{
+		imagedestroy($image);
+	}
+}

--- a/src/BarcodeGeneratorJPG.php
+++ b/src/BarcodeGeneratorJPG.php
@@ -2,21 +2,14 @@
 
 namespace Picqer\Barcode;
 
-use Imagick;
-
-class BarcodeGeneratorJPG extends BarcodeGeneratorPNG
+class BarcodeGeneratorJPG extends BarcodeGeneratorImage
 {
-    protected function createImagickImageObject(int $width, int $height): Imagick
-    {
-        $image = new Imagick();
-        $image->newImage($width, $height, 'white', 'JPG');
-
-        return $image;
-    }
+	const EXTENSION = 'JPG';
+	const DEFAULT_BACKGROUND_COLOR = 'white';
 
     protected function generateGdImage($image)
     {
         imagejpeg($image);
-        imagedestroy($image);
+		parent::generateGdImage($image);
     }
 }

--- a/src/BarcodeGeneratorPNG.php
+++ b/src/BarcodeGeneratorPNG.php
@@ -2,117 +2,14 @@
 
 namespace Picqer\Barcode;
 
-use Imagick;
-use imagickdraw;
-use imagickpixel;
-use Picqer\Barcode\Exceptions\BarcodeException;
-
-class BarcodeGeneratorPNG extends BarcodeGenerator
+class BarcodeGeneratorPNG extends BarcodeGeneratorImage
 {
-    protected $useImagick = true;
-
-    public function __construct()
-    {
-        // Auto switch between GD and Imagick based on what is installed
-        if (extension_loaded('imagick')) {
-            $this->useImagick = true;
-        } elseif (function_exists('imagecreate')) {
-            $this->useImagick = false;
-        } else {
-            throw new BarcodeException('Neither gd-lib or imagick are installed!');
-        }
-    }
-
-    /**
-     * Force the use of Imagick image extension
-     */
-    public function useImagick()
-    {
-        $this->useImagick = true;
-    }
-
-    /**
-     * Force the use of the GD image library
-     */
-    public function useGd()
-    {
-        $this->useImagick = false;
-    }
-
-    /**
-     * Return a PNG image representation of barcode (requires GD or Imagick library).
-     *
-     * @param string $barcode code to print
-     * @param string $type type of barcode:
-     * @param int $widthFactor Width of a single bar element in pixels.
-     * @param int $height Height of a single bar element in pixels.
-     * @param array $foregroundColor RGB (0-255) foreground color for bar elements (background is transparent).
-     * @return string image data or false in case of error.
-     */
-    public function getBarcode($barcode, $type, int $widthFactor = 2, int $height = 30, array $foregroundColor = [0, 0, 0])
-    {
-        $barcodeData = $this->getBarcodeData($barcode, $type);
-        $width = round($barcodeData->getWidth() * $widthFactor);
-
-        if ($this->useImagick) {
-            $imagickBarsShape = new imagickdraw();
-            $imagickBarsShape->setFillColor(new imagickpixel('rgb(' . implode(',', $foregroundColor) .')'));
-        } else {
-            $image = $this->createGdImageObject($width, $height);
-            $gdForegroundColor = imagecolorallocate($image, $foregroundColor[0], $foregroundColor[1], $foregroundColor[2]);
-        }
-
-        // print bars
-        $positionHorizontal = 0;
-        /** @var BarcodeBar $bar */
-        foreach ($barcodeData->getBars() as $bar) {
-            $barWidth = round(($bar->getWidth() * $widthFactor), 3);
-
-            if ($bar->isBar() && $barWidth > 0) {
-                $y = round(($bar->getPositionVertical() * $height / $barcodeData->getHeight()), 3);
-                $barHeight = round(($bar->getHeight() * $height / $barcodeData->getHeight()), 3);
-
-                // draw a vertical bar
-                if ($this->useImagick && isset($imagickBarsShape)) {
-                    $imagickBarsShape->rectangle($positionHorizontal, $y, ($positionHorizontal + $barWidth - 1), ($y + $barHeight));
-                } else {
-                    imagefilledrectangle($image, $positionHorizontal, $y, ($positionHorizontal + $barWidth - 1), ($y + $barHeight), $gdForegroundColor);
-                }
-            }
-            $positionHorizontal += $barWidth;
-        }
-
-        if ($this->useImagick && isset($imagickBarsShape)) {
-            $image = $this->createImagickImageObject($width, $height);
-            $image->drawImage($imagickBarsShape);
-            return $image->getImageBlob();
-        }
-
-        ob_start();
-        $this->generateGdImage($image);
-        return ob_get_clean();
-    }
-
-    protected function createGdImageObject(int $width, int $height)
-    {
-        $image = imagecreate($width, $height);
-        $colorBackground = imagecolorallocate($image, 255, 255, 255);
-        imagecolortransparent($image, $colorBackground);
-
-        return $image;
-    }
-
-    protected function createImagickImageObject(int $width, int $height): Imagick
-    {
-        $image = new Imagick();
-        $image->newImage($width, $height, 'none', 'PNG');
-
-        return $image;
-    }
+	const EXTENSION = 'PNG';
+	const DEFAULT_BACKGROUND_COLOR = 'none';
 
     protected function generateGdImage($image)
     {
         imagepng($image);
-        imagedestroy($image);
+        parent::generateGdImage($image);
     }
 }

--- a/tests/BarcodeJpgTest.php
+++ b/tests/BarcodeJpgTest.php
@@ -6,6 +6,10 @@ class BarcodeJpgTest extends TestCase
 {
     public function test_jpg_barcode_generator_can_generate_code_128_barcode()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorJPG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128);
@@ -20,6 +24,10 @@ class BarcodeJpgTest extends TestCase
 
     public function test_jpg_barcode_generator_can_generate_code_39_barcode()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorJPG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_39, 1);
@@ -34,6 +42,10 @@ class BarcodeJpgTest extends TestCase
 
     public function test_jpg_barcode_generator_can_use_different_height()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorJPG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128, 2, 45);
@@ -48,6 +60,10 @@ class BarcodeJpgTest extends TestCase
 
     public function test_jpg_barcode_generator_can_use_different_width_factor()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorJPG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128, 5);

--- a/tests/BarcodePngTest.php
+++ b/tests/BarcodePngTest.php
@@ -6,6 +6,10 @@ class BarcodePngTest extends TestCase
 {
     public function test_png_barcode_generator_can_generate_code_128_barcode()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorPNG();
         $generator->useGd();
         $generated = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128);
@@ -15,6 +19,10 @@ class BarcodePngTest extends TestCase
 
     public function test_png_barcode_generator_can_generate_code_39_barcode()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorPNG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_39, 1);
@@ -29,6 +37,10 @@ class BarcodePngTest extends TestCase
 
     public function test_png_barcode_generator_can_use_different_height()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorPNG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128, 2, 45);
@@ -43,6 +55,10 @@ class BarcodePngTest extends TestCase
 
     public function test_png_barcode_generator_can_use_different_width_factor()
     {
+		if (! extension_loaded('gd')) {
+			$this->markTestSkipped();
+		}
+
         $generator = new Picqer\Barcode\BarcodeGeneratorPNG();
         $generator->useGd();
         $result = $generator->getBarcode('081231723897', $generator::TYPE_CODE_128, 5);


### PR DESCRIPTION
I changed the two classes that export to image file so they are equally important, and create a common abstract class that keeps the common logic.

Then, when testing, I only had imagemagick enabled, so the test failed when it should be skipped due to having gd disabled, so I reused the same logic used for imagemagick (skip if not installed)