### PR TITLE
Fix phpdoc type case for usage with vimeo/psalm

### DIFF
--- a/src/BarcodeGeneratorDynamicHTML.php
+++ b/src/BarcodeGeneratorDynamicHTML.php
@@ -11,7 +11,7 @@ class BarcodeGeneratorDynamicHTML extends BarcodeGenerator
      * This 'dynamic' version uses percentage based widths and heights, resulting in a vector-y qualitative result.
      *
      * @param string $barcode code to print
-     * @param BarcodeGenerator::Type_* $type (string) type of barcode
+     * @param BarcodeGenerator::TYPE_* $type (string) type of barcode
      * @param string $foregroundColor Foreground color for bar elements as '#333' or 'orange' for example (background is transparent).
      * @return string HTML code.
      */

--- a/src/BarcodeGeneratorHTML.php
+++ b/src/BarcodeGeneratorHTML.php
@@ -9,7 +9,7 @@ class BarcodeGeneratorHTML extends BarcodeGenerator
      * This original version uses pixel based widths and heights. Use Dynamic HTML version for better quality representation.
      *
      * @param string $barcode code to print
-     * @param BarcodeGenerator::Type_* $type (string) type of barcode
+     * @param BarcodeGenerator::TYPE_* $type (string) type of barcode
      * @param int $widthFactor Width of a single bar element in pixels.
      * @param int $height Height of a single bar element in pixels.
      * @param string $foregroundColor Foreground color for bar elements as '#333' or 'orange' for example (background is transparent).

--- a/src/BarcodeGeneratorPNG.php
+++ b/src/BarcodeGeneratorPNG.php
@@ -46,7 +46,7 @@ class BarcodeGeneratorPNG extends BarcodeGenerator
      * Return a PNG image representation of barcode (requires GD or Imagick library).
      *
      * @param string $barcode code to print
-     * @param BarcodeGenerator::Type_* $type (string) type of barcode
+     * @param BarcodeGenerator::TYPE_* $type (string) type of barcode
      * @param int $widthFactor Width of a single bar element in pixels.
      * @param int $height Height of a single bar element in pixels.
      * @param array $foregroundColor RGB (0-255) foreground color for bar elements (background is transparent).

--- a/src/BarcodeGeneratorSVG.php
+++ b/src/BarcodeGeneratorSVG.php
@@ -8,7 +8,7 @@ class BarcodeGeneratorSVG extends BarcodeGenerator
      * Return a SVG string representation of barcode.
      *
      * @param $barcode (string) code to print
-     * @param BarcodeGenerator::Type_* $type (string) type of barcode
+     * @param BarcodeGenerator::TYPE_* $type (string) type of barcode
      * @param $widthFactor (float) Minimum width of a single bar in user units.
      * @param $height (float) Height of barcode in user units.
      * @param $foregroundColor (string) Foreground color (in SVG format) for bar elements (background is transparent).


### PR DESCRIPTION
The phpdoc type BarcodeGenerator::Type_* (with wrong case) is not recognized by vimeo/psalm, but BarcodeGenerator::TYPE_* (with correct case) is.

We found this issue because of the change in #176, which caused psalm to throw the following error:
```
InvalidArgument: Argument 2 of Picqer\Barcode\BarcodeGeneratorPNG::getBarcode expects Picqer\Barcode\BarcodeGenerator::Type_*, but 'C128' provided
```