### PR TITLE
ITF14 checksum fix

### DIFF
--- a/src/Types/TypeITF14.php
+++ b/src/Types/TypeITF14.php
@@ -5,6 +5,7 @@ namespace Picqer\Barcode\Types;
 use Picqer\Barcode\Barcode;
 use Picqer\Barcode\BarcodeBar;
 use Picqer\Barcode\Exceptions\InvalidCharacterException;
+use Picqer\Barcode\Exceptions\InvalidCheckDigitException;
 use Picqer\Barcode\Exceptions\InvalidLengthException;
 
 class TypeITF14 implements TypeInterface
@@ -12,6 +13,7 @@ class TypeITF14 implements TypeInterface
     /**
      * @throws InvalidLengthException
      * @throws InvalidCharacterException
+     * @throws InvalidCheckDigitException
      */
     public function getBarcodeData(string $code): Barcode
     {
@@ -35,6 +37,10 @@ class TypeITF14 implements TypeInterface
 
         if (strlen($code) === 13) {
             $code .= $this->getChecksum($code);
+        } elseif (substr($code, -1) !== $this->getChecksum(substr($code, 0, -1))) {
+            // If length of given barcode is same as final length, barcode is including checksum
+            // Make sure that checksum is the same as we calculated
+            throw new InvalidCheckDigitException();
         }
 
         $barcode = new Barcode($code);

--- a/src/Types/TypeITF14.php
+++ b/src/Types/TypeITF14.php
@@ -73,8 +73,8 @@ class TypeITF14 implements TypeInterface
         $total = 0;
 
         for ($charIndex = 0; $charIndex <= (strlen($code) - 1); $charIndex++) {
-            $integerOfChar = intval($code . substr($charIndex, 1));
-            $total += $integerOfChar * (($charIndex === 0 || $charIndex % 2 === 0) ? 3 : 1);
+            $integerOfChar = intval($code[$charIndex]);
+            $total += $integerOfChar * ($charIndex % 2 === 0 ? 3 : 1);
         }
 
         $checksum = 10 - ($total % 10);

--- a/tests/ChecksumBarcodeTest.php
+++ b/tests/ChecksumBarcodeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Picqer\Barcode\Types\TypeEan13;
+use Picqer\Barcode\Types\TypeInterface;
+use Picqer\Barcode\Types\TypeITF14;
+
+class ChecksumBarcodeTest extends TestCase
+{
+    public static $supportedBarcodes = [
+        ['type' => TypeEan13::class, 'barcodes' => [
+            '081231723897' => '0812317238973',
+            '004900000463' => '0049000004632',
+        ]],
+        ['type' => TypeITF14::class, 'barcodes' => [
+            '0001234560001' => '00012345600012',
+            '0540014128876' => '05400141288766',
+        ]],
+    ];
+
+    public function testAllSupportedBarcodeTypes()
+    {
+        foreach ($this::$supportedBarcodes as $barcodeTestSet) {
+            $barcodeType = $this->getBarcodeType($barcodeTestSet['type']);
+
+            foreach ($barcodeTestSet['barcodes'] as $testBarcode => $expectedBarcode) {
+                $this->assertEquals($expectedBarcode, $barcodeType->getBarcodeData($testBarcode)->getBarcode());
+            }
+        }
+    }
+
+
+    private function getBarcodeType(string $typeClass): TypeInterface
+    {
+        return new $typeClass;
+    }
+}


### PR DESCRIPTION
Fixed wrong ITF14/GTIN14 checksum calculation. Also throws InvalidCheckDigitException when wrong check digit is provided.

Checksum calculation fixed according to https://www.gs1.org/services/how-calculate-check-digit-manually