### PR TITLE
Fix TypeCode128 AB sequence detection

### DIFF
--- a/src/Types/TypeCode128.php
+++ b/src/Types/TypeCode128.php
@@ -390,7 +390,7 @@ class TypeCode128 implements TypeInterface
         // get A sequences (if any)
         $numseq = [];
         preg_match_all('/([\x00-\x1f])/', $code, $numseq, PREG_OFFSET_CAPTURE);
-        if (empty($numseq[1])) {
+        if (! empty($numseq[1])) {
             $end_offset = 0;
             foreach ($numseq[1] as $val) {
                 $offset = $val[1];


### PR DESCRIPTION
fixes https://github.com/picqer/php-barcode-generator/commit/e9d39681f617705492b609fc3fc58465ef88e8fd

Group separator (ASCII 29) incorrectly detected as type B after error in linked commit.

![Screenshot 2025-06-03 at 10 54 27](https://github.com/user-attachments/assets/035bf1c1-f7d1-4d52-9a22-9bb10aadfb09)
