### PR TITLE
Fix avoid imagedestroy on PHP 8+

### DIFF
--- a/src/Renderers/JpgRenderer.php
+++ b/src/Renderers/JpgRenderer.php
@@ -25,9 +25,5 @@ class JpgRenderer extends PngRenderer
     protected function generateGdImage($image): void
     {
         \imagejpeg($image);
-
-        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
-            \imagedestroy($image);
-        }
     }
 }

--- a/src/Renderers/JpgRenderer.php
+++ b/src/Renderers/JpgRenderer.php
@@ -25,6 +25,9 @@ class JpgRenderer extends PngRenderer
     protected function generateGdImage($image): void
     {
         \imagejpeg($image);
-        \imagedestroy($image);
+
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            \imagedestroy($image);
+        }
     }
 }

--- a/src/Renderers/PngRenderer.php
+++ b/src/Renderers/PngRenderer.php
@@ -148,6 +148,9 @@ class PngRenderer implements RendererInterface
     protected function generateGdImage($image): void
     {
         \imagepng($image);
-        \imagedestroy($image);
+
+        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            \imagedestroy($image);
+        }
     }
 }

--- a/src/Renderers/PngRenderer.php
+++ b/src/Renderers/PngRenderer.php
@@ -148,9 +148,5 @@ class PngRenderer implements RendererInterface
     protected function generateGdImage($image): void
     {
         \imagepng($image);
-
-        if (version_compare(PHP_VERSION, '8.0.0', '<')) {
-            \imagedestroy($image);
-        }
     }
 }


### PR DESCRIPTION
### Summary
This PR removes all imagedestroy() calls from the GD image generation logic.

Since the project only supports PHP ≥ 8.2, GD images are objects and calling imagedestroy() has no effect and is deprecated.

### Changes included
- Removed all `imagedestroy()` calls
- Avoided deprecated and no-op behavior on PHP 8+

### Motivation
`imagedestroy()` has been deprecated since PHP 8.5 and has no effect since PHP 8.0. Removing it aligns the codebase with the supported PHP versions and avoids deprecation warnings while keeping the code clean and forward-compatible.

**Detected deprecation messages:**
```bash
/var/www/app.dev/vendor/picqer/php-barcode-generator/src/Renderers/PngRenderer.php:151 Function imagedestroy() is deprecated since 8.5, as it has no effect since PHP 8.0
/var/www/app.dev/vendor/picqer/php-barcode-generator/src/Renderers/JpgRenderer.php:28 Function imagedestroy() is deprecated since 8.5, as it has no effect since PHP 8.0
```